### PR TITLE
error early in the parser if the scheme version is not 1, add a test

### DIFF
--- a/src/menhir_parser.mly
+++ b/src/menhir_parser.mly
@@ -20,7 +20,8 @@ let identifier_core :=
         {
             if swh <> "swh" then
               raise (Parser_error "Scheme incorrect")
-
+            else if scheme_v <> 1 then
+              raise (Parser_error "Invalid scheme versions")
             else
               let obj_id = String.lowercase_ascii hash in
 

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -38,7 +38,12 @@ let () =
      ; ( "sh:1:cnt:ffacc412c4e5ff55cafccd6e58bc58072c17ff6b"
        , "parser error: Scheme incorrect" )
        (* invalid object id "L33T" is too short *)
-     ; ("swh:1:dir:L33T", "parser error: Invalid object id")
+     ; ("swh:1:dir:L33T", "parser error: Invalid object id") (* *)
+     ; ( "swh:1:cnt:ffacc412c4e5fz55cafccd6e58bc58072c17ff6b"
+       , "parser error: Invalid object id" )
+       (* *)
+     ; ( "swh:2:cnt:ffacc412c4e5fa55cafccd6e58bc58072c17ff6b"
+       , "parser error: Invalid scheme versions" )
        (* invalid object id "ffacc412c4e5ff55cafccd6e58bc58072c17ff:" has an unwanted ':' *)
      ; ( "swh:1:cnt:ffacc412c4e5ff55cafccd6e58bc58072c17ff6:"
        , "parser error: Invalid object id" )


### PR DESCRIPTION
case with an invalid hash